### PR TITLE
BugFix: incorrect type

### DIFF
--- a/src/submodels/force_resolution.cu
+++ b/src/submodels/force_resolution.cu
@@ -177,7 +177,7 @@ FLAMEGPU_EXIT_CONDITION(calculate_convergence) {
     const float dt = FLAMEGPU->environment.getProperty<float>("dt");
     const unsigned int step_size = FLAMEGPU->environment.getProperty<unsigned int>("step_size");
 
-    if (FLAMEGPU->getStepCounter() + 1 < FLAMEGPU->environment.getProperty<unsigned int>("min_force_resolution_steps")) {
+    if (FLAMEGPU->getStepCounter() + 1 < FLAMEGPU->environment.getProperty<int>("min_force_resolution_steps")) {
         // Force resolution must always run at least 2 steps, maybe more
         // First pass step counter == 0, 2nd == 1 etc
         return flamegpu::CONTINUE;


### PR DESCRIPTION
This was exposed by the GLM type deduction patch to FGPU2.

This was a 'safe' bug, so builds against versions of FGPU2 earlier than https://github.com/FLAMEGPU/FLAMEGPU2/commit/81ba3e1f997a88152ae46e475547750fb9bccb5f should be fine without this patch.