### PR TITLE
Fix: When cellularity==0, report volume_ratio==1

### DIFF
--- a/orchestrator_src/main.cu
+++ b/orchestrator_src/main.cu
@@ -114,8 +114,13 @@ FLAMEGPU_EXIT_FUNCTION(ConstructPrimageOutput) {
                 t *= k / threshold;
             dummy_V += t;
         }
-        sim_out.tumour_volume = static_cast<float>(dummy_V);
-        sim_out.total_volume_ratio_updated = sim_out.tumour_volume / init_volume_calculated;
+        if (TOTAL_CELL_COUNT) {
+            sim_out.tumour_volume = static_cast<float>(dummy_V);
+            sim_out.total_volume_ratio_updated = sim_out.tumour_volume / init_volume_calculated;
+        } else {
+            sim_out.tumour_volume = init_volume_calculated;
+            sim_out.total_volume_ratio_updated = 1.0f;
+        }
     }
     if (NB_living_count) {
         sim_out.ratio_VEGF_NB_SC = Schwann.count() ? Neuroblastoma.sum<int>("VEGF") / static_cast<float>(Schwann.count()) : 0;

--- a/orchestrator_src/structures.h
+++ b/orchestrator_src/structures.h
@@ -5,7 +5,7 @@
 #include <vector>
 
 struct Version {
-    int number[3] = {13, 8, 3};
+    int number[3] = {13, 8, 4};
     bool warn_flag = false;
 };
 /**


### PR DESCRIPTION
Vinicius has provided some bad outputs, whereby `total_volume_ratio_updated` reported is `>2`, in both these cases the reported cellularity was `0`.

This attempts to provide an acute fix (rather than always clamping the reported value).

I will test this and bump the version number before merging.

<details>
<summary>

`input-179915.json`

</summary>

```json
{
    "version": [
        0,
        13,
        5,
        false
    ],
    "config": {
        "seed": 159874,
        "steps": 336,
        "environment": {
            "TERT_rarngm": 0,
            "ATRX_inact": 1,
            "V_tumour": 3.20678,
            "O2": 0.004855,
            "cellularity": [
                0.541806,
                0.0,
                0.0,
                0.0,
                0.0,
                0.0
            ],
            "orchestrator_time": 0,
            "MYCN_amp": 0,
            "ALT": 1,
            "ALK": 0,
            "gradiff": 2,
            "histology_init": 1,
            "nb_telomere_length_mean": 0.5707364359455991,
            "nb_telomere_length_sd": 0.7314539905971278,
            "sc_telomere_length_mean": 0.46601130551533765,
            "sc_telomere_length_sd": 0.1295948327843588,
            "extent_of_differentiation_mean": 0.671709595572549,
            "extent_of_differentiation_sd": 0.17567089268685365,
            "nb_necro_signal_mean": 0.22178401166403672,
            "nb_necro_signal_sd": 0.5666668979054125,
            "nb_apop_signal_mean": 0.10429165350300063,
            "nb_apop_signal_sd": 0.2637989045209166,
            "sc_necro_signal_mean": 0.3964882795506237,
            "sc_necro_signal_sd": 0.47442807462990144,
            "sc_apop_signal_mean": 0.47651045304702433,
            "sc_apop_signal_sd": 0.34921416665387495,
            "drug_effects": [
                1.0,
                1.0,
                0.0,
                1.0,
                1.0,
                0.0
            ],
            "start_effects": [
                0
            ],
            "end_effects": [
                144
            ]
        }
    }
}
```


</details>

<details>
<summary>

`input-206854.json`

</summary>


```json
{
    "version": [
        0,
        13,
        5,
        false
    ],
    "config": {
        "seed": 159874,
        "steps": 336,
        "environment": {
            "TERT_rarngm": 0,
            "ATRX_inact": 1,
            "V_tumour": 1.56403,
            "O2": 0.001706,
            "cellularity": [
                0.682274,
                0.0,
                0.0,
                0.0,
                0.0,
                0.0
            ],
            "orchestrator_time": 0,
            "MYCN_amp": 0,
            "ALT": 1,
            "ALK": 0,
            "gradiff": 2,
            "histology_init": 1,
            "nb_telomere_length_mean": 0.7703411631588644,
            "nb_telomere_length_sd": 0.262316594331953,
            "sc_telomere_length_mean": 0.3671461449953367,
            "sc_telomere_length_sd": 0.8298225280713849,
            "extent_of_differentiation_mean": 0.7138391321122854,
            "extent_of_differentiation_sd": 0.0594975349400505,
            "nb_necro_signal_mean": 0.9978204367005176,
            "nb_necro_signal_sd": 0.050839792865617794,
            "nb_apop_signal_mean": 0.20028373705451752,
            "nb_apop_signal_sd": 0.3427823502008589,
            "sc_necro_signal_mean": 0.00891148988004109,
            "sc_necro_signal_sd": 0.7365847417517309,
            "sc_apop_signal_mean": 0.4802112904654321,
            "sc_apop_signal_sd": 0.8608766605249382,
            "drug_effects": [
                1.0,
                1.0,
                0.0,
                1.0,
                1.0,
                0.0
            ],
            "start_effects": [
                0
            ],
            "end_effects": [
                144
            ]
        }
    }
}
```

</details>

<details>
<summary>

`output-179915.json`

</summary>

```json
{
	"version": [
		13,
		8,
		2,
		false
	],
	"primage": {
		"delta_O2": 0.00020849984139204025,
		"O2": 0.005063499789685011,
		"delta_ecm": 0.0,
		"ecm": 0.4581940174102783,
		"material_properties": 0.0,
		"diffusion_coefficient": 0.0,
		"total_volume_ratio_updated": 6.701258659362793,
		"cellularity": [
			0.0,
			0.0,
			0.0,
			0.0,
			0.0,
			0.0
		],
		"tumour_volume": 21.48946189880371,
		"ratio_VEGF_NB_SC": 0.0,
		"nb_telomere_length_mean": 0.0,
		"nb_telomere_length_sd": 0.0,
		"sc_telomere_length_mean": 0.0,
		"sc_telomere_length_sd": 0.0,
		"nb_necro_signal_mean": 0.0,
		"nb_necro_signal_sd": 0.0,
		"nb_apop_signal_mean": 0.0,
		"nb_apop_signal_sd": 0.0,
		"sc_necro_signal_mean": 0.0,
		"sc_necro_signal_sd": 0.0,
		"sc_apop_signal_mean": 0.0,
		"sc_apop_signal_sd": 0.0,
		"extent_of_differentiation_mean": 0.0,
		"extent_of_differentiation_sd": 0.0
	}
}
```

</details>

<details>
<summary>

`output-206854.json`

</summary>

```json
{
	"version": [
		13,
		8,
		2,
		false
	],
	"primage": {
		"delta_O2": 0.00026098359376192093,
		"O2": 0.0019669835455715658,
		"delta_ecm": 0.0,
		"ecm": 0.3177260160446167,
		"material_properties": 0.0,
		"diffusion_coefficient": 0.0,
		"total_volume_ratio_updated": 7.138739109039307,
		"cellularity": [
			0.0,
			0.0,
			0.0,
			0.0,
			0.0,
			0.0
		],
		"tumour_volume": 11.165202140808106,
		"ratio_VEGF_NB_SC": 0.0,
		"nb_telomere_length_mean": 0.0,
		"nb_telomere_length_sd": 0.0,
		"sc_telomere_length_mean": 0.0,
		"sc_telomere_length_sd": 0.0,
		"nb_necro_signal_mean": 0.0,
		"nb_necro_signal_sd": 0.0,
		"nb_apop_signal_mean": 0.0,
		"nb_apop_signal_sd": 0.0,
		"sc_necro_signal_mean": 0.0,
		"sc_necro_signal_sd": 0.0,
		"sc_apop_signal_mean": 0.0,
		"sc_apop_signal_sd": 0.0,
		"extent_of_differentiation_mean": 0.0,
		"extent_of_differentiation_sd": 0.0
	}
}
```

</details>

