### PR TITLE
Bessemer A100 scripts -> orchestrator_release

### DIFF
--- a/.github/workflows/Ubuntu.yml
+++ b/.github/workflows/Ubuntu.yml
@@ -91,6 +91,8 @@ jobs:
         -DCMAKE_WARN_DEPRECATED="OFF" 
         -DWARNINGS_AS_ERRORS="ON"
         -DCUDA_ARCH="${{ env.CUDA_ARCH }}"
+        -DUSE_NVCC_THREADS="OFF"
+        -DSEATBELTS="OFF"
 
     - name: Build
       working-directory: ${{ env.BUILD_DIR }}

--- a/.github/workflows/Windows.yml
+++ b/.github/workflows/Windows.yml
@@ -68,6 +68,8 @@ jobs:
         -DCMAKE_WARN_DEPRECATED="OFF"
         -DWARNINGS_AS_ERRORS="ON"
         -DCUDA_ARCH="${{ env.CUDA_ARCH }}"
+        -DUSE_NVCC_THREADS="OFF"
+        -DSEATBELTS="OFF"
 
     - name: Build
       working-directory: ${{ env.BUILD_DIR }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,7 @@ SET(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/bin/${CMAKE_BUILD
 # Prepare list of source files
 # Can't do this automatically, as CMake wouldn't know when to regen (as CMakeLists.txt would be unchanged)
 SET(COMMON_SRC
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/chemo_len.h
     ${CMAKE_CURRENT_SOURCE_DIR}/src/header.h
     ${CMAKE_CURRENT_SOURCE_DIR}/src/environment.cu
     ${CMAKE_CURRENT_SOURCE_DIR}/src/agents/neuroblastoma.cu
@@ -58,7 +59,7 @@ SET(ORCHESTRATOR_SRC
     ${CMAKE_CURRENT_SOURCE_DIR}/orchestrator_src/main.h
     ${CMAKE_CURRENT_SOURCE_DIR}/orchestrator_src/main.cu
     ${CMAKE_CURRENT_SOURCE_DIR}/orchestrator_src/json.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/orchestrator_src/json_in.cu
+    ${CMAKE_CURRENT_SOURCE_DIR}/orchestrator_src/json_in.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/orchestrator_src/json_out.cpp
 )
 add_flamegpu_executable(${PROJECT_NAME} "${ORCHESTRATOR_SRC}" "${FLAMEGPU_ROOT}" "${PROJECT_BINARY_DIR}" TRUE)  

--- a/orchestrator_src/json.h
+++ b/orchestrator_src/json.h
@@ -2,7 +2,7 @@
 #define ORCHESTRATOR_SRC_JSON_H_
 
 #include <string>
-
+#include "chemo_len.h"
 #include "structures.h"
 
 OrchestratorInput readOrchestratorInput(const std::string& inputFile);

--- a/orchestrator_src/json_in.cpp
+++ b/orchestrator_src/json_in.cpp
@@ -9,7 +9,6 @@
 #include <set>
 
 #include "json.h"
-#include "header.h"
 /**
  * This is the main sax style parser for the json state
  * It stores it's current position within the hierarchy with mode, lastKey and current_variable_array_index

--- a/orchestrator_src/main.cu
+++ b/orchestrator_src/main.cu
@@ -244,6 +244,8 @@ int main(int argc, const char** argv) {
     sim_out.delta_ecm = sim_out.ecm - (1 - cellularity_sum);
     // Write orchestrator output to disk
     writeOrchestratorOutput(sim_out, cfg.primageOutputFile);
+    // Output simulation time
+    printf("Simulation completed in %f seconds!\n", sim.getElapsedTimeSimulation());
     return 0;
 }
 RunConfig parseArgs(int argc, const char** argv) {

--- a/scripts/build_on_bessemer_a100.sh
+++ b/scripts/build_on_bessemer_a100.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+#SBATCH --time=00:30:00
+#SBATCH --job-name=compile.a100-tmp.sh
+
+# Must compile for the A100 nodes on the A100 nodes for the correct CPU arch
+#SBATCH --partition=gpu-a100-tmp
+#SBATCH --qos=gpu
+#SBATCH --gres=gpu:1
+
+# 12 CPU cores (1/4th of the node) and 1 GPUs worth of memory < 1/4th of the node)
+#SBATCH --cpus-per-task=12
+#SBATCH --mem=80G
+## Name of file to which standard output will be redirected
+#SBATCH --output="build_output.out"
+## Name of file to which the standard error stream will be redirected
+#SBATCH --error="build_error.err"
+
+## Default pre-job stuff
+## srun /bin/hostname
+cd $SLURM_SUBMIT_DIR
+
+## Start job
+
+# Use A100 specific module environment
+module unuse /usr/local/modulefiles/live/eb/all
+module unuse /usr/local/modulefiles/live/noeb
+module use /usr/local/modulefiles/staging/eb-znver3/all/
+
+# Load modules from the A100 specific environment
+module load GCC/11.2.0
+module load CUDA/11.4.1
+module load CMake/3.21.1-GCCcore-11.2.0
+
+mkdir -p build && cd build
+
+cmake .. -DCMAKE_BUILD_TYPE=Release -DVISUALISATION=OFF -DSEATBELTS=OFF -DCUDA_ARCH="80"
+
+cmake --build . --target all --parallel 6

--- a/scripts/test_run_on_bessemer_a100.sh
+++ b/scripts/test_run_on_bessemer_a100.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+#SBATCH --time=00:30:00
+#SBATCH --job-name=compile.a100-tmp.sh
+
+# Must compile for the A100 nodes on the A100 nodes for the correct CPU arch
+#SBATCH --partition=gpu-a100-tmp
+#SBATCH --qos=gpu
+#SBATCH --gres=gpu:1
+
+# 12 CPU cores (1/4th of the node) and 1 GPUs worth of memory < 1/4th of the node)
+#SBATCH --cpus-per-task=12
+#SBATCH --mem=80G
+## Name of file to which standard output will be redirected
+#SBATCH --output="test_run_output.out"
+## Name of file to which the standard error stream will be redirected
+#SBATCH --error="test_run_error.err"
+
+## Default pre-job stuff
+## srun /bin/hostname
+cd $SLURM_SUBMIT_DIR
+
+## Start job
+
+# Use A100 specific module environment
+module unuse /usr/local/modulefiles/live/eb/all
+module unuse /usr/local/modulefiles/live/noeb
+module use /usr/local/modulefiles/staging/eb-znver3/all/
+
+# Load modules from the A100 specific environment
+module load GCC/11.2.0
+module load CUDA/11.4.1
+module load CMake/3.21.1-GCCcore-11.2.0
+
+nvidia-smi
+
+./build/bin/Release/orchestrator_FGPUNB --in inputs/in-2022-03-29.json --primage inputs/out-2022-03-29.json

--- a/src/chemo_len.h
+++ b/src/chemo_len.h
@@ -1,0 +1,7 @@
+#ifndef SRC_CHEMO_LEN_H_
+#define SRC_CHEMO_LEN_H_
+
+// If chemo len is too high, environment gets too big
+#define CHEMO_LEN 200
+
+#endif  // SRC_CHEMO_LEN_H_

--- a/src/header.h
+++ b/src/header.h
@@ -8,8 +8,7 @@
 #define GRID_MAX_DIMENSIONS 151
 #define GMD GRID_MAX_DIMENSIONS
 // If chemo len is too high, environment gets too big
-#define CHEMO_LEN 200
-
+#include "chemo_len.h"
 /**
  * Define model
  */


### PR DESCRIPTION
Have been testing the orchestrator model on Bessemer's A100s this morning, new scripts included.

Had to tweak the code slightly, as bare nvcc wasn't happy with RapidJSON for some reason, but worked as expected when compiled with g++ (which necessitated splitting a header).